### PR TITLE
Add category CRUD support with image handling

### DIFF
--- a/Category.cs
+++ b/Category.cs
@@ -1,0 +1,10 @@
+namespace TestCustomerWinForms.Net8
+{
+    public class Category
+    {
+        public int CategoryID { get; set; }
+        public string CategoryName { get; set; } = string.Empty;
+        public string? Description { get; set; }
+        public byte[]? Picture { get; set; }
+    }
+}

--- a/CategoryForm.Designer.cs
+++ b/CategoryForm.Designer.cs
@@ -1,0 +1,240 @@
+namespace TestCustomerWinForms.Net8
+{
+    partial class CategoryForm
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.dgv = new System.Windows.Forms.DataGridView();
+            this.label1 = new System.Windows.Forms.Label();
+            this.txtId = new System.Windows.Forms.TextBox();
+            this.label2 = new System.Windows.Forms.Label();
+            this.txtName = new System.Windows.Forms.TextBox();
+            this.label3 = new System.Windows.Forms.Label();
+            this.txtDescription = new System.Windows.Forms.TextBox();
+            this.label4 = new System.Windows.Forms.Label();
+            this.picPicture = new System.Windows.Forms.PictureBox();
+            this.btnLoadImage = new System.Windows.Forms.Button();
+            this.btnClearImage = new System.Windows.Forms.Button();
+            this.btnLoad = new System.Windows.Forms.Button();
+            this.btnAdd = new System.Windows.Forms.Button();
+            this.btnUpdate = new System.Windows.Forms.Button();
+            this.btnDelete = new System.Windows.Forms.Button();
+            this.btnClear = new System.Windows.Forms.Button();
+            ((System.ComponentModel.ISupportInitialize)(this.dgv)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.picPicture)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // dgv
+            // 
+            this.dgv.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.dgv.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
+            this.dgv.Location = new System.Drawing.Point(12, 211);
+            this.dgv.MultiSelect = false;
+            this.dgv.Name = "dgv";
+            this.dgv.ReadOnly = true;
+            this.dgv.SelectionMode = System.Windows.Forms.DataGridViewSelectionMode.FullRowSelect;
+            this.dgv.Size = new System.Drawing.Size(560, 138);
+            this.dgv.TabIndex = 0;
+            this.dgv.CellClick += new System.Windows.Forms.DataGridViewCellEventHandler(this.dgv_CellClick);
+            // 
+            // label1
+            // 
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 14);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(68, 15);
+            this.label1.TabIndex = 1;
+            this.label1.Text = "Category ID";
+            // 
+            // txtId
+            // 
+            this.txtId.Location = new System.Drawing.Point(107, 11);
+            this.txtId.Name = "txtId";
+            this.txtId.ReadOnly = true;
+            this.txtId.Size = new System.Drawing.Size(150, 23);
+            this.txtId.TabIndex = 2;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(12, 49);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(94, 15);
+            this.label2.TabIndex = 3;
+            this.label2.Text = "Category Name";
+            // 
+            // txtName
+            // 
+            this.txtName.Location = new System.Drawing.Point(107, 46);
+            this.txtName.Name = "txtName";
+            this.txtName.Size = new System.Drawing.Size(250, 23);
+            this.txtName.TabIndex = 4;
+            // 
+            // label3
+            // 
+            this.label3.AutoSize = true;
+            this.label3.Location = new System.Drawing.Point(12, 84);
+            this.label3.Name = "label3";
+            this.label3.Size = new System.Drawing.Size(67, 15);
+            this.label3.TabIndex = 5;
+            this.label3.Text = "Description";
+            // 
+            // txtDescription
+            // 
+            this.txtDescription.Location = new System.Drawing.Point(107, 81);
+            this.txtDescription.Multiline = true;
+            this.txtDescription.Name = "txtDescription";
+            this.txtDescription.Size = new System.Drawing.Size(250, 60);
+            this.txtDescription.TabIndex = 6;
+            // 
+            // label4
+            // 
+            this.label4.AutoSize = true;
+            this.label4.Location = new System.Drawing.Point(370, 14);
+            this.label4.Name = "label4";
+            this.label4.Size = new System.Drawing.Size(46, 15);
+            this.label4.TabIndex = 7;
+            this.label4.Text = "Picture";
+            // 
+            // picPicture
+            // 
+            this.picPicture.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            this.picPicture.Location = new System.Drawing.Point(370, 32);
+            this.picPicture.Name = "picPicture";
+            this.picPicture.Size = new System.Drawing.Size(150, 120);
+            this.picPicture.SizeMode = System.Windows.Forms.PictureBoxSizeMode.Zoom;
+            this.picPicture.TabIndex = 8;
+            this.picPicture.TabStop = false;
+            // 
+            // btnLoadImage
+            // 
+            this.btnLoadImage.Location = new System.Drawing.Point(370, 158);
+            this.btnLoadImage.Name = "btnLoadImage";
+            this.btnLoadImage.Size = new System.Drawing.Size(75, 23);
+            this.btnLoadImage.TabIndex = 9;
+            this.btnLoadImage.Text = "Load...";
+            this.btnLoadImage.UseVisualStyleBackColor = true;
+            this.btnLoadImage.Click += new System.EventHandler(this.btnLoadImage_Click);
+            // 
+            // btnClearImage
+            // 
+            this.btnClearImage.Location = new System.Drawing.Point(451, 158);
+            this.btnClearImage.Name = "btnClearImage";
+            this.btnClearImage.Size = new System.Drawing.Size(75, 23);
+            this.btnClearImage.TabIndex = 10;
+            this.btnClearImage.Text = "Clear";
+            this.btnClearImage.UseVisualStyleBackColor = true;
+            this.btnClearImage.Click += new System.EventHandler(this.btnClearImage_Click);
+            // 
+            // btnLoad
+            // 
+            this.btnLoad.Location = new System.Drawing.Point(15, 177);
+            this.btnLoad.Name = "btnLoad";
+            this.btnLoad.Size = new System.Drawing.Size(75, 23);
+            this.btnLoad.TabIndex = 11;
+            this.btnLoad.Text = "Load";
+            this.btnLoad.UseVisualStyleBackColor = true;
+            this.btnLoad.Click += new System.EventHandler(this.btnLoad_Click);
+            // 
+            // btnAdd
+            // 
+            this.btnAdd.Location = new System.Drawing.Point(96, 177);
+            this.btnAdd.Name = "btnAdd";
+            this.btnAdd.Size = new System.Drawing.Size(75, 23);
+            this.btnAdd.TabIndex = 12;
+            this.btnAdd.Text = "Add";
+            this.btnAdd.UseVisualStyleBackColor = true;
+            this.btnAdd.Click += new System.EventHandler(this.btnAdd_Click);
+            // 
+            // btnUpdate
+            // 
+            this.btnUpdate.Location = new System.Drawing.Point(177, 177);
+            this.btnUpdate.Name = "btnUpdate";
+            this.btnUpdate.Size = new System.Drawing.Size(75, 23);
+            this.btnUpdate.TabIndex = 13;
+            this.btnUpdate.Text = "Update";
+            this.btnUpdate.UseVisualStyleBackColor = true;
+            this.btnUpdate.Click += new System.EventHandler(this.btnUpdate_Click);
+            // 
+            // btnDelete
+            // 
+            this.btnDelete.Location = new System.Drawing.Point(258, 177);
+            this.btnDelete.Name = "btnDelete";
+            this.btnDelete.Size = new System.Drawing.Size(75, 23);
+            this.btnDelete.TabIndex = 14;
+            this.btnDelete.Text = "Delete";
+            this.btnDelete.UseVisualStyleBackColor = true;
+            this.btnDelete.Click += new System.EventHandler(this.btnDelete_Click);
+            // 
+            // btnClear
+            // 
+            this.btnClear.Location = new System.Drawing.Point(339, 177);
+            this.btnClear.Name = "btnClear";
+            this.btnClear.Size = new System.Drawing.Size(75, 23);
+            this.btnClear.TabIndex = 15;
+            this.btnClear.Text = "Clear";
+            this.btnClear.UseVisualStyleBackColor = true;
+            this.btnClear.Click += new System.EventHandler(this.btnClear_Click);
+            // 
+            // CategoryForm
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(584, 361);
+            this.Controls.Add(this.btnClear);
+            this.Controls.Add(this.btnDelete);
+            this.Controls.Add(this.btnUpdate);
+            this.Controls.Add(this.btnAdd);
+            this.Controls.Add(this.btnLoad);
+            this.Controls.Add(this.btnClearImage);
+            this.Controls.Add(this.btnLoadImage);
+            this.Controls.Add(this.picPicture);
+            this.Controls.Add(this.label4);
+            this.Controls.Add(this.txtDescription);
+            this.Controls.Add(this.label3);
+            this.Controls.Add(this.txtName);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.txtId);
+            this.Controls.Add(this.label1);
+            this.Controls.Add(this.dgv);
+            this.MinimumSize = new System.Drawing.Size(600, 400);
+            this.Name = "CategoryForm";
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Text = "Categories";
+            ((System.ComponentModel.ISupportInitialize)(this.dgv)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.picPicture)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
+        }
+
+        private System.Windows.Forms.DataGridView dgv;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox txtId;
+        private System.Windows.Forms.Label label2;
+        private System.Windows.Forms.TextBox txtName;
+        private System.Windows.Forms.Label label3;
+        private System.Windows.Forms.TextBox txtDescription;
+        private System.Windows.Forms.Label label4;
+        private System.Windows.Forms.PictureBox picPicture;
+        private System.Windows.Forms.Button btnLoadImage;
+        private System.Windows.Forms.Button btnClearImage;
+        private System.Windows.Forms.Button btnLoad;
+        private System.Windows.Forms.Button btnAdd;
+        private System.Windows.Forms.Button btnUpdate;
+        private System.Windows.Forms.Button btnDelete;
+        private System.Windows.Forms.Button btnClear;
+    }
+}

--- a/CategoryForm.cs
+++ b/CategoryForm.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Drawing;
+using System.IO;
+using System.Windows.Forms;
+
+namespace TestCustomerWinForms.Net8
+{
+    public partial class CategoryForm : Form
+    {
+        private readonly CategoryRepository _repo = new CategoryRepository();
+
+        public CategoryForm()
+        {
+            InitializeComponent();
+        }
+
+        private void LoadGrid()
+        {
+            try
+            {
+                var data = _repo.GetAll();
+                dgv.DataSource = data;
+                dgv.AutoResizeColumns();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to load data.\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void ClearInputs()
+        {
+            txtId.Text = "";
+            txtName.Text = "";
+            txtDescription.Text = "";
+            picPicture.Image = null;
+            txtName.Focus();
+        }
+
+        private void btnLoad_Click(object? sender, EventArgs e) => LoadGrid();
+
+        private byte[]? GetImageBytes()
+        {
+            if (picPicture.Image == null) return null;
+            using var ms = new MemoryStream();
+            picPicture.Image.Save(ms, picPicture.Image.RawFormat);
+            return ms.ToArray();
+        }
+
+        private void btnAdd_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                var name = (txtName.Text ?? string.Empty).Trim();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    MessageBox.Show("Category Name is required.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                var desc = txtDescription.Text;
+                var pic = GetImageBytes();
+                var id = _repo.Add(new Category { CategoryName = name, Description = desc, Picture = pic });
+                txtId.Text = id.ToString();
+                LoadGrid();
+                foreach (DataGridViewRow row in dgv.Rows)
+                {
+                    if (row.DataBoundItem is Category c && c.CategoryID == id)
+                    {
+                        row.Selected = true;
+                        dgv.FirstDisplayedScrollingRowIndex = row.Index;
+                        break;
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to add category.\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void btnUpdate_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (!int.TryParse(txtId.Text, out int id))
+                {
+                    MessageBox.Show("Select a category to update.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                var name = (txtName.Text ?? string.Empty).Trim();
+                if (string.IsNullOrWhiteSpace(name))
+                {
+                    MessageBox.Show("Category Name is required.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                var desc = txtDescription.Text;
+                var pic = GetImageBytes();
+                _repo.Update(new Category { CategoryID = id, CategoryName = name, Description = desc, Picture = pic });
+                LoadGrid();
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to update category.\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void btnDelete_Click(object? sender, EventArgs e)
+        {
+            try
+            {
+                if (!int.TryParse(txtId.Text, out int id))
+                {
+                    MessageBox.Show("Select a category to delete.", "Validation", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+                    return;
+                }
+                var confirm = MessageBox.Show("Are you sure you want to delete this category?", "Confirm", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (confirm == DialogResult.Yes)
+                {
+                    _repo.Delete(id);
+                    LoadGrid();
+                    ClearInputs();
+                }
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to delete category.\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void btnClear_Click(object? sender, EventArgs e) => ClearInputs();
+
+        private void dgv_CellClick(object? sender, DataGridViewCellEventArgs e)
+        {
+            if (e.RowIndex >= 0 && e.RowIndex < dgv.Rows.Count)
+            {
+                var row = dgv.Rows[e.RowIndex];
+                if (row.DataBoundItem is Category c)
+                {
+                    txtId.Text = c.CategoryID.ToString();
+                    txtName.Text = c.CategoryName;
+                    txtDescription.Text = c.Description ?? "";
+                    picPicture.Image = c.Picture != null ? Image.FromStream(new MemoryStream(c.Picture)) : null;
+                }
+            }
+        }
+
+        private void btnLoadImage_Click(object? sender, EventArgs e)
+        {
+            using var ofd = new OpenFileDialog { Filter = "Images|*.png;*.jpg;*.jpeg;*.gif;*.bmp" };
+            if (ofd.ShowDialog() == DialogResult.OK)
+            {
+                picPicture.Image = Image.FromFile(ofd.FileName);
+            }
+        }
+
+        private void btnClearImage_Click(object? sender, EventArgs e) => picPicture.Image = null;
+    }
+}

--- a/CategoryForm.resx
+++ b/CategoryForm.resx
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/CategoryRepository.cs
+++ b/CategoryRepository.cs
@@ -1,0 +1,72 @@
+using Microsoft.Data.SqlClient;
+using System;
+using System.Collections.Generic;
+using System.Data;
+
+namespace TestCustomerWinForms.Net8
+{
+    public class CategoryRepository
+    {
+        private readonly string _connString;
+
+        public CategoryRepository()
+        {
+            _connString = AppConfig.ConnString;
+        }
+
+        public List<Category> GetAll()
+        {
+            var list = new List<Category>();
+            using var conn = new SqlConnection(_connString);
+            using var cmd = new SqlCommand("SELECT CategoryID, CategoryName, Description, Picture FROM dbo.Categories ORDER BY CategoryID", conn);
+            conn.Open();
+            using var reader = cmd.ExecuteReader();
+            while (reader.Read())
+            {
+                list.Add(new Category
+                {
+                    CategoryID = reader.GetInt32(0),
+                    CategoryName = reader.IsDBNull(1) ? "" : reader.GetString(1),
+                    Description = reader.IsDBNull(2) ? null : reader.GetString(2),
+                    Picture = reader.IsDBNull(3) ? null : (byte[])reader[3]
+                });
+            }
+            return list;
+        }
+
+        public int Add(Category c)
+        {
+            using var conn = new SqlConnection(_connString);
+            using var cmd = new SqlCommand(@"INSERT INTO dbo.Categories (CategoryName, Description, Picture) VALUES (@name, @desc, @pic);
+                                             SELECT CAST(SCOPE_IDENTITY() AS int);", conn);
+            cmd.Parameters.Add("@name", SqlDbType.NVarChar, 200).Value = (object?)c.CategoryName ?? DBNull.Value;
+            cmd.Parameters.Add("@desc", SqlDbType.NVarChar, -1).Value = (object?)c.Description ?? DBNull.Value;
+            cmd.Parameters.Add("@pic", SqlDbType.VarBinary, -1).Value = (object?)c.Picture ?? DBNull.Value;
+            conn.Open();
+            var newId = (int)cmd.ExecuteScalar()!;
+            return newId;
+        }
+
+        public void Update(Category c)
+        {
+            using var conn = new SqlConnection(_connString);
+            using var cmd = new SqlCommand("UPDATE dbo.Categories SET CategoryName=@name, Description=@desc, Picture=@pic WHERE CategoryID=@id", conn);
+            cmd.Parameters.Add("@name", SqlDbType.NVarChar, 200).Value = (object?)c.CategoryName ?? DBNull.Value;
+            cmd.Parameters.Add("@desc", SqlDbType.NVarChar, -1).Value = (object?)c.Description ?? DBNull.Value;
+            cmd.Parameters.Add("@pic", SqlDbType.VarBinary, -1).Value = (object?)c.Picture ?? DBNull.Value;
+            cmd.Parameters.Add("@id", SqlDbType.Int).Value = c.CategoryID;
+            conn.Open();
+            var rows = cmd.ExecuteNonQuery();
+            if (rows == 0) throw new InvalidOperationException("No rows updated. Check CategoryID.");
+        }
+
+        public void Delete(int id)
+        {
+            using var conn = new SqlConnection(_connString);
+            using var cmd = new SqlCommand("DELETE FROM dbo.Categories WHERE CategoryID=@id", conn);
+            cmd.Parameters.Add("@id", SqlDbType.Int).Value = id;
+            conn.Open();
+            cmd.ExecuteNonQuery();
+        }
+    }
+}

--- a/CustomerRepository.cs
+++ b/CustomerRepository.cs
@@ -16,6 +16,8 @@ namespace TestCustomerWinForms.Net8
 
         public List<Customer> GetAll()
         {
+            //// Just checking github
+
             var list = new List<Customer>();
             using var conn = new SqlConnection(_connString);
             using var cmd = new SqlCommand("SELECT CustomerID, CustomerName FROM dbo.tblTestCustomer ORDER BY CustomerID", conn);

--- a/Program.cs
+++ b/Program.cs
@@ -9,7 +9,7 @@ namespace TestCustomerWinForms.Net8
         static void Main()
         {
             ApplicationConfiguration.Initialize();
-            Application.Run(new MainForm());
+            Application.Run(new CategoryForm());
         }
     }
 }

--- a/schema.sql
+++ b/schema.sql
@@ -7,3 +7,15 @@ BEGIN
         CustomerName NVARCHAR(200)     NULL
     );
 END;
+
+-- Run this to create the Categories table if it doesn't exist
+IF OBJECT_ID('dbo.Categories', 'U') IS NULL
+BEGIN
+    CREATE TABLE dbo.Categories
+    (
+        CategoryID   INT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+        CategoryName NVARCHAR(200)     NULL,
+        Description  NVARCHAR(MAX)     NULL,
+        Picture      VARBINARY(MAX)    NULL
+    );
+END;


### PR DESCRIPTION
## Summary
- introduce `Category` entity with repository for `[dbo].[Categories]`
- add `CategoryForm` UI enabling CRUD operations and image upload/clear
- run Category form at startup and update schema script for Categories table

## Testing
- `dotnet build` *(fails: Microsoft.NET.Sdk.WindowsDesktop.targets not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e56023bc832a848c2138426a811d